### PR TITLE
캐싱 방법 리팩토링 #58

### DIFF
--- a/src/favorite/favorites.service.ts
+++ b/src/favorite/favorites.service.ts
@@ -14,18 +14,9 @@ export class FavoritesService {
     private readonly favoritesRepository: FavoriteRepository,
     private readonly usersRepository: UsersRepository,
     private readonly toiletsRepository: ToiletRepository,
-    // private readonly redisService: RedisService,
   ) {}
 
   async getLiked(toiletId: number, socialId: string) {
-    // const cacheKey = `favorite:user:${socialId}:toilet:${toiletId}`;
-    // const cached = await this.redisService.get<{
-    // like: boolean;
-    // count: number;
-    // }>(cacheKey);
-
-    // if (cached) return cached;
-
     const user = await this.usersRepository.findBySocialId(socialId);
 
     if (!user) throw new NotFoundException('유저를 찾을 수 없습니다.');
@@ -39,7 +30,6 @@ export class FavoritesService {
       like: !!hasLiked,
     };
 
-    // await this.redisService.set(cacheKey, result, 60);
     return result;
   }
 
@@ -68,8 +58,6 @@ export class FavoritesService {
     if (existingLike) {
       throw new ConflictException('이미 좋아요를 추가한 화장실입니다.');
     }
-
-    // await this.invalidateCache(socialId, toiletId);
 
     return await this.favoritesRepository.createLike(user, toilet);
   }
@@ -102,18 +90,6 @@ export class FavoritesService {
       );
     }
 
-    // await this.invalidateCache(socialId, toiletId);
-
     return await this.favoritesRepository.deleteLike(user, toilet);
   }
-
-  // private async invalidateCache(socialId: string, toiletId: number) {
-  //   const userKey = `favorite:user:${socialId}:toilet:${toiletId}`;
-  //   const publicKey = `favorite:public:toilet:${toiletId}`;
-
-  // await Promise.all([
-  // this.redisService.del(userKey),
-  // this.redisService.del(publicKey),
-  // ]);
-  // }
 }

--- a/src/toilet/toilet.service.ts
+++ b/src/toilet/toilet.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { FavoritesService } from 'src/favorite/favorites.service';
-// import { RedisService } from 'src/cache/redis.service';
+import { RedisService } from 'src/cache/redis.service';
 import {
   ToiletMapResponseDto,
   ToiletMapResponseWrapperDto,
@@ -14,7 +14,7 @@ export class ToiletService {
   constructor(
     private readonly toiletRepository: ToiletRepository,
     private readonly favoritesService: FavoritesService,
-    // private readonly redisService: RedisService,
+    private readonly redisService: RedisService,
   ) {}
 
   async getToilets(
@@ -29,13 +29,13 @@ export class ToiletService {
       .map(([k, v]) => `${k}=${v}`)
       .join('|');
 
-    // const cacheKey = `toilets:${cenLat}:${cenLng}:${top}:${bottom}:${left}:${right}:${userSocialId || 'public'}:filters:${filterKey}`;
-    // const cached =
-    // await this.redisService.get<ToiletMapResponseWrapperDto>(cacheKey);
+    const cacheKey = `toilets:${cenLat}:${cenLng}:${top}:${bottom}:${left}:${right}:filters:${filterKey}`;
+    const cached =
+      await this.redisService.get<ToiletMapResponseWrapperDto>(cacheKey);
 
-    // if (cached) {
-    // return cached;
-    // }
+    if (cached) {
+      return cached;
+    }
 
     const toilets = await this.toiletRepository.findToiletsInBounds(
       cenLat,

--- a/src/toilet/toilet.service.ts
+++ b/src/toilet/toilet.service.ts
@@ -68,7 +68,7 @@ export class ToiletService {
       groups: groupedToilets,
     };
 
-    // await this.redisService.set(cacheKey, response, 300);
+    await this.redisService.set(cacheKey, response, 300);
     return response;
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#58 캐싱 방법 리팩토링

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존에 회원정보도 함께 캐싱하던 방식을 변경 (회원정보 x, 화장실정보만)
화장실 상세페이지 캐싱은 동일한 요청이 오기 희박하므로 캐싱하지않음

화장실 목록조회 (메인페이지) -회원정보 캐싱 제거
댓글 목록 조회시에만 캐싱 진행 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?